### PR TITLE
[chore] 공통 예외 처리 설정 및 mybatis 기본 설정

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -12,3 +12,7 @@ spring:
       pool:
         core-size: 5
         max-size: 10
+mybatis:
+  mapper-locations: classpath:mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,6 +24,7 @@ ext {
 
 dependencies {
     implementation 'org.springframework.modulith:spring-modulith-starter-core'
+    implementation 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,7 +24,8 @@ ext {
 
 dependencies {
     implementation 'org.springframework.modulith:spring-modulith-starter-core'
-    implementation 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/core/src/main/java/com/reverse/core/exception/ErrorResponse.java
+++ b/core/src/main/java/com/reverse/core/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package com.reverse.core.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp;
+
+    private final String message;
+
+    @Builder
+    public ErrorResponse(String message) {
+        this.timestamp = LocalDateTime.now();
+        this.message = message;
+    }
+
+    public static ErrorResponse of(Exception exception) {
+        return ErrorResponse.builder().message(exception.getMessage()).build();
+    }
+}

--- a/core/src/main/java/com/reverse/core/exception/ForbiddenException.java
+++ b/core/src/main/java/com/reverse/core/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.reverse.core.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/reverse/core/exception/GlobalExceptionHandler.java
+++ b/core/src/main/java/com/reverse/core/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.reverse.core.exception;
+
+import com.reverse.rhight.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorizedException(UnauthorizedException ex) {
+        log.error("UnauthorizedException 발생:  Message: {}", ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.fail(ex));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbiddenException(ForbiddenException ex) {
+        log.error("ForbiddenException 발생:  Message: {}", ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.fail(ex));
+    }
+
+    // JSON 파싱/바인딩 실패
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex) {
+        ErrorResponse error = ErrorResponse.builder().message("요청 본문(JSON) 형식이 올바르지 않습니다.").build();
+
+        return ResponseEntity.badRequest().body(ApiResponse.fail(error));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception ex) {
+        log.error("예상치 못한 에러 발생: ", ex);
+
+        ErrorResponse error = ErrorResponse.builder().message("서버 내부 오류가 발생했습니다.").build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(error));
+    }
+}

--- a/core/src/main/java/com/reverse/core/exception/GlobalExceptionHandler.java
+++ b/core/src/main/java/com/reverse/core/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.reverse.core.exception;
 
-import com.reverse.rhight.global.response.ApiResponse;
+
+import com.reverse.core.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/core/src/main/java/com/reverse/core/exception/UnauthorizedException.java
+++ b/core/src/main/java/com/reverse/core/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.reverse.core.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/reverse/core/response/ApiResponse.java
+++ b/core/src/main/java/com/reverse/core/response/ApiResponse.java
@@ -1,0 +1,30 @@
+package com.reverse.core.response;
+
+import com.reverse.rhight.global.exception.ErrorResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final ErrorResponse error;
+
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(true, null, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> fail(Exception exception) {
+        return new ApiResponse<>(false, null, ErrorResponse.of(exception));
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorResponse error) {
+        return new ApiResponse<>(false, null, error);
+    }
+}

--- a/core/src/main/java/com/reverse/core/response/ApiResponse.java
+++ b/core/src/main/java/com/reverse/core/response/ApiResponse.java
@@ -1,6 +1,6 @@
 package com.reverse.core.response;
 
-import com.reverse.rhight.global.exception.ErrorResponse;
+import com.reverse.core.exception.ErrorResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #1 

## 📝 변경 사항

## 🛠 작업 유형
- [ ] 🐞 버그 수정 (Bug Fix)
- [x] ✨ 신규 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일/UI 수정 (Style/UI)
- [ ] 📝 문서 업데이트 (Documentation)
- [x] 🔧 설정 변경 (Config)

## ✅ 체크리스트
- [ ] 브라우저에서 화면이 잘 보이는지 확인했나요? (Chrome, Safari 등)
- [ ] 모바일/태블릿 화면(반응형)에서 깨짐이 없나요?
- [ ] 불필요한 `console.log`나 주석을 제거했나요?
- [ ] 코딩 컨벤션(Prettier/ESLint)을 준수했나요?

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 중앙 집중식 예외 처리 및 일관된 API 응답 래퍼(ApiResponse) 추가
  * HTTP 상태 코드별 오류 응답 제공(401, 403, 400, 500)
  * 구조화된 오류 페이로드(ErrorResponse)에 메시지와 타임스탬프 포함

* **Chores**
  * MyBatis 설정 재적용으로 데이터베이스 매핑 동작 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->