### PR TITLE
[feat] 근태 화면에서 팀원들의 휴가관련 전자결재 리스트 가져오는 API 구현 (#108)

### DIFF
--- a/approval/src/main/java/com/reverse/approval/internal/application/ApprovalService.java
+++ b/approval/src/main/java/com/reverse/approval/internal/application/ApprovalService.java
@@ -4,6 +4,7 @@ import com.reverse.approval.ApprovalFacade;
 import com.reverse.approval.internal.domain.enums.ApprovalStatus;
 import com.reverse.approval.internal.domain.enums.DocumentBoxType;
 import com.reverse.approval.internal.domain.enums.ProgressTabType;
+import com.reverse.approval.internal.domain.enums.VacationType;
 import com.reverse.approval.internal.dto.request.ApprovalLineRequest;
 import com.reverse.approval.internal.dto.request.ApprovalProcessRequest;
 import com.reverse.approval.internal.dto.request.DraftApproval;
@@ -17,6 +18,7 @@ import com.reverse.approval.internal.dto.response.ApprovalMainSummaryResponse;
 import com.reverse.approval.internal.dto.response.ApprovalProgressOverviewResponse;
 import com.reverse.approval.internal.dto.response.ApprovalProgressPageResponse;
 import com.reverse.approval.internal.dto.response.ApprovalReviewPageResponse;
+import com.reverse.approval.internal.dto.response.ApprovalVacationPageResponse;
 import com.reverse.approval.internal.dto.response.DownloadedApprovalFile;
 import com.reverse.approval.internal.exception.ApprovalNotFoundException;
 import com.reverse.approval.internal.exception.AttachmentNotFoundException;
@@ -53,6 +55,7 @@ import com.reverse.approval.internal.persistence.row.ApprovalLineRow;
 import com.reverse.approval.internal.persistence.row.ApprovalProgressCountsRow;
 import com.reverse.approval.internal.persistence.row.ApprovalProgressRow;
 import com.reverse.approval.internal.persistence.row.ApprovalReviewRow;
+import com.reverse.approval.internal.persistence.row.ApprovalVacationRow;
 import com.reverse.approval.internal.persistence.row.BusinessTripDetailRow;
 import com.reverse.approval.internal.persistence.row.FlexibleWorkDetailRow;
 import com.reverse.approval.internal.persistence.row.LeaveDetailRow;
@@ -73,7 +76,9 @@ import com.reverse.core.exception.ForbiddenException;
 import com.reverse.core.service.NumberingService;
 import com.reverse.hr.HrFacade;
 import com.reverse.hr.dto.EmployeeProfileDTO;
+import com.reverse.hr.dto.OrganizationMemberInfo;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
@@ -358,6 +363,39 @@ public class ApprovalService implements ApprovalFacade {
 
         boolean hasNext = page + 1 < totalPages;
         return new ApprovalReviewPageResponse(
+                content, page, size, totalElements, totalPages, hasNext);
+    }
+
+    @Transactional(readOnly = true)
+    public ApprovalVacationPageResponse getAdminVacationList(Long employeeId, int page, int size) {
+        if (page < 0) {
+            throw new BadRequestException("page는 0 이상이어야 합니다.");
+        }
+        if (size <= 0) {
+            throw new BadRequestException("size는 1 이상이어야 합니다.");
+        }
+
+        List<Long> employeeIds =
+                hrFacade.getMyOrganizationMembers(employeeId).stream()
+                        .map(OrganizationMemberInfo::employeeId)
+                        .distinct()
+                        .toList();
+
+        if (employeeIds.isEmpty()) {
+            return new ApprovalVacationPageResponse(List.of(), page, size, 0, 0, false);
+        }
+
+        int totalElements = nvl(approvalMapper.countAdminVacationApprovals(employeeIds));
+        int totalPages = totalElements == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+        int offset = page * size;
+
+        List<ApprovalVacationPageResponse.ApprovalVacationItem> content =
+                approvalMapper.findAdminVacationApprovals(employeeIds, offset, size).stream()
+                        .map(this::toApprovalVacationItem)
+                        .toList();
+
+        boolean hasNext = page + 1 < totalPages;
+        return new ApprovalVacationPageResponse(
                 content, page, size, totalElements, totalPages, hasNext);
     }
 
@@ -904,6 +942,36 @@ public class ApprovalService implements ApprovalFacade {
                 row.drafterName(),
                 row.departmentName(),
                 row.draftDate());
+    }
+
+    private ApprovalVacationPageResponse.ApprovalVacationItem toApprovalVacationItem(
+            ApprovalVacationRow row) {
+        return new ApprovalVacationPageResponse.ApprovalVacationItem(
+                row.approvalId(),
+                row.docId(),
+                row.docType(),
+                row.approvalStatus(),
+                row.drafterId(),
+                row.drafterName(),
+                row.departmentName(),
+                row.vacationType(),
+                row.startDate(),
+                row.endDate(),
+                calculateVacationDays(row.vacationType(), row.startDate(), row.endDate()),
+                row.reason(),
+                row.draftDate());
+    }
+
+    private double calculateVacationDays(
+            String vacationType, LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate == null || endDate == null) {
+            return 0;
+        }
+        if (VacationType.HALF.name().equalsIgnoreCase(vacationType)) {
+            return 0.5;
+        }
+        long days = ChronoUnit.DAYS.between(startDate.toLocalDate(), endDate.toLocalDate()) + 1;
+        return Math.max(0, days);
     }
 
     private ApprovalDashboardResponse.PendingReviewItem toDashboardPendingReviewItem(

--- a/approval/src/main/java/com/reverse/approval/internal/dto/response/ApprovalVacationPageResponse.java
+++ b/approval/src/main/java/com/reverse/approval/internal/dto/response/ApprovalVacationPageResponse.java
@@ -1,0 +1,27 @@
+package com.reverse.approval.internal.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ApprovalVacationPageResponse(
+        List<ApprovalVacationItem> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext) {
+    public record ApprovalVacationItem(
+            Long approvalId,
+            String docId,
+            String docType,
+            String approvalStatus,
+            Long drafterId,
+            String drafterName,
+            String departmentName,
+            String vacationType,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            double days,
+            String reason,
+            LocalDateTime draftDate) {}
+}

--- a/approval/src/main/java/com/reverse/approval/internal/persistence/ApprovalMapper.java
+++ b/approval/src/main/java/com/reverse/approval/internal/persistence/ApprovalMapper.java
@@ -10,6 +10,7 @@ import com.reverse.approval.internal.persistence.row.ApprovalMainItemRow;
 import com.reverse.approval.internal.persistence.row.ApprovalProgressCountsRow;
 import com.reverse.approval.internal.persistence.row.ApprovalProgressRow;
 import com.reverse.approval.internal.persistence.row.ApprovalReviewRow;
+import com.reverse.approval.internal.persistence.row.ApprovalVacationRow;
 import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
@@ -95,6 +96,13 @@ public interface ApprovalMapper {
 
     List<ApprovalMainItemRow> findMainInProgressApprovals(
             @Param("employeeId") Long employeeId, @Param("size") int size);
+
+    Integer countAdminVacationApprovals(@Param("employeeIds") List<Long> employeeIds);
+
+    List<ApprovalVacationRow> findAdminVacationApprovals(
+            @Param("employeeIds") List<Long> employeeIds,
+            @Param("offset") int offset,
+            @Param("size") int size);
 
     Optional<ApprovalHeaderRow> findApprovalHeaderByApprovalId(
             @Param("approvalId") Long approvalId);

--- a/approval/src/main/java/com/reverse/approval/internal/persistence/row/ApprovalVacationRow.java
+++ b/approval/src/main/java/com/reverse/approval/internal/persistence/row/ApprovalVacationRow.java
@@ -1,0 +1,17 @@
+package com.reverse.approval.internal.persistence.row;
+
+import java.time.LocalDateTime;
+
+public record ApprovalVacationRow(
+        Long approvalId,
+        String docId,
+        String docType,
+        String approvalStatus,
+        Long drafterId,
+        String drafterName,
+        String departmentName,
+        String vacationType,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String reason,
+        LocalDateTime draftDate) {}

--- a/approval/src/main/java/com/reverse/approval/internal/web/ApprovalAdminController.java
+++ b/approval/src/main/java/com/reverse/approval/internal/web/ApprovalAdminController.java
@@ -1,0 +1,35 @@
+package com.reverse.approval.internal.web;
+
+import com.reverse.approval.internal.application.ApprovalService;
+import com.reverse.approval.internal.dto.response.ApprovalVacationPageResponse;
+import com.reverse.core.response.ApiResponse;
+import com.reverse.core.security.CustomUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/approval/admin")
+public class ApprovalAdminController {
+
+    private final ApprovalService approvalService;
+
+    @Operation(summary = "휴가 신청 목록 조회 (관리자)")
+    @GetMapping("/vacation-list")
+    @SecurityRequirement(name = "JWT")
+    public ResponseEntity<ApiResponse<ApprovalVacationPageResponse>> getVacationList(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal CustomUser user) {
+        ApprovalVacationPageResponse response =
+                approvalService.getAdminVacationList(user.getEmployeeId(), page, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/approval/src/main/java/com/reverse/approval/internal/web/ApprovalAdminController.java
+++ b/approval/src/main/java/com/reverse/approval/internal/web/ApprovalAdminController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +25,7 @@ public class ApprovalAdminController {
     @Operation(summary = "휴가 신청 목록 조회 (관리자)")
     @GetMapping("/vacation-list")
     @SecurityRequirement(name = "JWT")
+    @PreAuthorize("hasAnyRole('EVALUATOR','HR_ADMIN_MASTER','HR_ADMIN_BASIC','SYSTEM_ADMIN')")
     public ResponseEntity<ApiResponse<ApprovalVacationPageResponse>> getVacationList(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,

--- a/approval/src/main/resources/mapper/ApprovalMapper.xml
+++ b/approval/src/main/resources/mapper/ApprovalMapper.xml
@@ -591,6 +591,45 @@
         LIMIT #{size}
     </select>
 
+    <select id="countAdminVacationApprovals" resultType="int">
+        SELECT COUNT(*)
+        FROM electronic_approval ea
+        JOIN vacation_detail vd
+          ON vd.approval_id = ea.approval_id
+        WHERE ea.doc_type = 'VACATION'
+          AND ea.drafter_id IN
+        <foreach collection="employeeIds" item="employeeId" open="(" separator="," close=")">
+            #{employeeId}
+        </foreach>
+    </select>
+
+    <select id="findAdminVacationApprovals"
+            resultType="com.reverse.approval.internal.persistence.row.ApprovalVacationRow">
+        SELECT
+            ea.approval_id AS approvalId,
+            ea.doc_id AS docId,
+            ea.doc_type AS docType,
+            ea.approval_status AS approvalStatus,
+            ea.drafter_id AS drafterId,
+            ea.drafter_name AS drafterName,
+            ea.department_name AS departmentName,
+            vd.vacation_type AS vacationType,
+            vd.start_dt AS startDate,
+            vd.end_dt AS endDate,
+            vd.reason AS reason,
+            ea.draft_dt AS draftDate
+        FROM electronic_approval ea
+        JOIN vacation_detail vd
+          ON vd.approval_id = ea.approval_id
+        WHERE ea.doc_type = 'VACATION'
+          AND ea.drafter_id IN
+        <foreach collection="employeeIds" item="employeeId" open="(" separator="," close=")">
+            #{employeeId}
+        </foreach>
+        ORDER BY ea.draft_dt DESC, ea.approval_id DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
     <select id="findApprovalHeaderByApprovalId"
             resultType="com.reverse.approval.internal.persistence.row.ApprovalHeaderRow">
         SELECT


### PR DESCRIPTION
﻿## 📌 관련 이슈
- Closes #108 

## 📝 변경 사항
- 근태 화면에서 팀원들의 휴가관련 전자결재 리스트 가져오는 API 구현
## 🛠 작업 유형
- [ ] 🐞 버그 수정 (Bug Fix)
- [x] ✨ 신규 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] 🔧 설정 변경 (Config)
- [ ] 🗃️ DB 스키마 변경 (Migration)

## ✅ 체크리스트
- [ ] 변경 이유와 구현 내용을 스스로 리뷰했나요?
- [ ] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했나요?
- [ ] 코딩 컨벤션(Formatter/Linter)을 준수했나요?
- [ ] 단위/통합 테스트를 추가 또는 수정했고 로컬에서 통과했나요?
- [ ] API 스펙 변경 사항(요청/응답/에러 코드)을 문서화했나요? (해당 시)
- [ ] 예외 처리 및 에러 응답이 기존 규약과 일치하나요?
- [ ] 트랜잭션 범위와 데이터 정합성 영향을 검토했나요?
- [ ] DB 마이그레이션/롤백 전략을 확인했나요? (해당 시)
- [ ] 보안 영향(인증/인가/민감정보 로그 노출)을 검토했나요?
- [ ] 성능 영향(N+1, 인덱스, 쿼리 비용)을 검토했나요? (해당 시)

## 🧪 테스트 방법
- 예: `./gradlew test`

## 🎸 기타
